### PR TITLE
Add minimal image for ts-derp-docker

### DIFF
--- a/.github/workflows/docker-publish-minimal.yml
+++ b/.github/workflows/docker-publish-minimal.yml
@@ -1,0 +1,49 @@
+name: docker-build-minimal
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  multi-arch-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free space on runner
+        run: |
+          sudo rm -rf /usr/local/lib/android
+      -
+        name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # ping@v6.0.1
+        with:
+          fetch-depth: 0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # pin@v3.7.0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # pin@v3.11.1
+      - 
+        name: Login to GitHub Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_PAT }}
+      -
+         name: Get Latest Tag
+         id: previoustag
+         uses: WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce # pin@v1.4.0
+      -
+        name: Build and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # pin@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile.minimal
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
+          push: true
+          tags: |
+            ghcr.io/erisa/ts-derper:latest-minimal
+            ghcr.io/erisa/ts-derper:${{ steps.previoustag.outputs.tag }}-minimal
+          cache-from: type=gha,mode=max
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish-minimal.yml
+++ b/.github/workflows/docker-publish-minimal.yml
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
           push: true
           tags: |
-            ghcr.io/erisa/ts-derper:latest-minimal
-            ghcr.io/erisa/ts-derper:${{ steps.previoustag.outputs.tag }}-minimal
+            ghcr.io/${{ github.actor }}/ts-derper:latest-minimal
+            ghcr.io/${{ github.actor }}/ts-derper:${{ steps.previoustag.outputs.tag }}-minimal
           cache-from: type=gha,mode=max
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/s390x,linux/ppc64le,linux/riscv64
           push: true
           tags: |
-            ghcr.io/erisa/ts-derper:latest
-            ghcr.io/erisa/ts-derper:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.actor }}/ts-derper:latest
+            ghcr.io/${{ github.actor }}/ts-derper:${{ steps.previoustag.outputs.tag }}
           cache-from: type=gha,mode=max
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,16 @@
 ARG ALPINE_VERSION=3.23
 
 ## Build container
-
 FROM --platform=${BUILDPLATFORM} alpine:${ALPINE_VERSION} AS builder
-LABEL org.opencontainers.image.source=https://github.com/Erisa/ts-derp-docker
 
 ### Build argument(s)
+ARG TARGETOS TARGETARCH
 ARG TAILSCALE_VERSION=v1.92.2
 
-### Build dependancies
-RUN apk add --no-cache git bash curl --no-cache
-
-ARG TARGETOS
-ARG TARGETARCH
-
 WORKDIR /build
+
+### Install build dependancies
+RUN apk add --no-cache git bash curl
 
 ### Clone the right version of Tailscale
 RUN git clone https://github.com/tailscale/tailscale --depth=1 --branch ${TAILSCALE_VERSION} .
@@ -24,16 +20,13 @@ RUN git clone https://github.com/tailscale/tailscale --depth=1 --branch ${TAILSC
 RUN mkdir binout && GOOS=${TARGETOS} GOARCH=${TARGETARCH} ./tool/go build -o ./binout . ./cmd/tailscale ./cmd/tailscaled ./cmd/derper ./cmd/containerboot 
 
 ## Runtime container
-
 FROM alpine:${ALPINE_VERSION}
 
 ### Runtime dependancies
 RUN apk add --no-cache curl iptables iproute2
 
 COPY --from=builder /build/binout/* /usr/local/bin/
-
-COPY init.sh /init.sh
-RUN chmod +x /init.sh
+COPY --chmod=755 init.sh /init.sh
 
 ### Unless changed
 EXPOSE 80/tcp
@@ -41,3 +34,5 @@ EXPOSE 443/tcp
 EXPOSE 3478/udp
 
 ENTRYPOINT ["/init.sh"]
+
+LABEL org.opencontainers.image.source=https://github.com/Erisa/ts-derp-docker

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -7,7 +7,7 @@ FROM --platform=${BUILDPLATFORM} alpine:${ALPINE_VERSION} AS builder
 ### Build argument(s)
 ARG TARGETOS TARGETARCH
 ARG TAILSCALE_VERSION=v1.92.2
-ARG FEATURETAGS="acme,cli,clientmetrics,dns,hujsonconf,netstack,osrouter,tailnetlock,unixsocketidentity"
+ARG FEATURETAGS="acme,cli,clientmetrics,dns,hujsonconf,netstack,osrouter,serve,tailnetlock,unixsocketidentity"
 
 WORKDIR /build
 

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,0 +1,44 @@
+# Global arguments
+ARG ALPINE_VERSION=3.23
+
+## Build container
+FROM --platform=${BUILDPLATFORM} alpine:${ALPINE_VERSION} AS builder
+
+### Build argument(s)
+ARG TARGETOS TARGETARCH
+ARG TAILSCALE_VERSION=v1.92.2
+ARG FEATURETAGS="acme,cli,clientmetrics,dns,hujsonconf,netstack,osrouter,tailnetlock,unixsocketidentity"
+
+WORKDIR /build
+
+### Install dependancies and clone the right version of Tailscale
+RUN apk add --no-cache git bash curl --no-cache && \
+    git clone https://github.com/tailscale/tailscale --depth=1 --branch ${TAILSCALE_VERSION} . && \
+    mkdir binout
+
+### Define build tags from featuretags and build all the needed binaries
+RUN export TAGS=$(GOOS=${TARGETOS} GOARCH=${TARGETARCH} ./tool/go run \
+        cmd/featuretags/featuretags.go -min -add $FEATURETAGS) && \
+        
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} ./tool/go build \
+        -o ./binout -trimpath -ldflags "-w -s" -tags $TAGS \
+        . ./cmd/tailscaled ./cmd/derper ./cmd/containerboot 
+
+## Runtime container
+FROM alpine:${ALPINE_VERSION}
+
+COPY --from=builder /build/binout/* /usr/local/bin/
+COPY --chmod=755 init.sh /init.sh
+
+### Add runtime dependancies and symlink tailscaled --> tailscale
+RUN apk add --no-cache curl iptables iproute2 && \
+    cd /usr/local/bin && ln -s tailscaled tailscale
+
+### Unless changed
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 3478/udp
+
+ENTRYPOINT ["/init.sh"]
+
+LABEL org.opencontainers.image.source=https://github.com/Erisa/ts-derp-docker


### PR DESCRIPTION
This PR adds a `Dockerfile.minimal` image built with [limited feature flags](https://github.com/stratself/ts-derp-docker/blob/main/Dockerfile.minimal#L10), intended to be used only as a DERP and not much more. Some notes:

- `tailscale` and `tailscaled` are [combined](https://tailscale.com/kb/1207/small-tailscale#step-1-building-tailscale) in a single binary. Results in a 70.1MB image from the original 132MB on x86
- `acme,hujsonconf,serve,tailnetlock` seems to be needed for `containerboot`, lest errors occur
- `clientmetrics` is needed for `netstack`

For CI I basically just copypasted `docker-publish.yml`. Images are being built on `ghcr.io/stratself/ts-derp-docker:latest-minimal` - I've just been able to test on x86_64 though